### PR TITLE
Install mux headers

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -38,3 +38,7 @@ copy src\webp\encode.h %LIBRARY_PREFIX%\include\webp\
 if errorlevel 1 exit 1
 copy src\webp\types.h %LIBRARY_PREFIX%\include\webp\
 if errorlevel 1 exit 1
+copy src\webp\mux.h %LIBRARY_PREFIX%\include\webp\
+if errorlevel 1 exit 1
+copy src\webp\mux_types.h %LIBRARY_PREFIX%\include\webp\
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2fc8bbde9f97f2ab403c0224fb9ca62b2e6852cbc519e91ceaa7c153ffd88a0c
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}


### PR DESCRIPTION
Follow up to https://github.com/conda-forge/libwebp-base-feedstock/pull/5 . For feature parity with *nix, we need to also install the `mux.h` and `mux_types.h` headers.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
