### PR TITLE
BUG: Revert build to autotools for osx ABI compatability

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,24 +4,29 @@ set -ex
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 
-mkdir build
-cd build
+# The libwebp build script doesn't pick all the other libraries up on its own
+# (even though it should by using PREFIX), so pass all the necessary parameters
+# for finding other imaging libraries to the configure script.
+./configure \
+    --disable-dependency-tracking \
+    --disable-gl \
+    --disable-static \
+    --enable-libwebpdecoder \
+    --enable-libwebpdemux \
+    --enable-libwebpmux \
+    --prefix=${PREFIX} \
 
-cmake .. ${CMAKE_ARGS} \
-	-DBUILD_SHARED_LIBS:BOOL=ON \
-	-DCMAKE_INSTALL_PREFIX=$PREFIX \
-	-DWEBP_BUILD_CWEBP:BOOL=OFF \
-	-DWEBP_BUILD_DWEBP:BOOL=OFF \
-	-DWEBP_BUILD_EXTRAS:BOOL=OFF \
-	-DWEBP_BUILD_GIF2WEBP:BOOL=OFF \
-	-DWEBP_BUILD_IMG2WEBP:BOOL=OFF \
-	-DWEBP_BUILD_LIBWEBPMUX:BOOL=ON \
-	-DWEBP_BUILD_VWEBP:BOOL=OFF \
-	-DWEBP_BUILD_WEBP_JS:BOOL=OFF \
-	-DWEBP_BUILD_WEBPINFO:BOOL=OFF \
-	-DWEBP_BUILD_WEBPMUX:BOOL=OFF \
-	-DWEBP_LINK_STATIC:BOOL=OFF \
+make -j${CPU_COUNT}
 
-cmake --build .
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
+make check
+fi
 
-cmake --install .
+make install
+
+rm -f $PREFIX/bin/cwebp
+rm -f $PREFIX/bin/dwebp
+rm -f $PREFIX/bin/gif2webp
+rm -f $PREFIX/bin/img2webp
+rm -f $PREFIX/bin/webpinfo
+rm -f $PREFIX/bin/webpmux

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f5d7ab2390b06b8a934a4fc35784291b3885b557780d099bd32f09241f9d83f9
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_subpackage('libwebp-base') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - cmake >=3.7
     - libtool  # [unix]
     - make     # [unix]
   run_constrained:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #11 