### PR TITLE
Move CMake config to standard location on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,10 @@ test:
       # absence of static libraries; removed in v1.2.3
       # should not be packaged in conda-forge, see also CFEP-18
       - test ! -f $PREFIX/lib/{{ each_lib }}.a                # [unix]
+
+      # config files; unix currently doesn't have CMake, only pkgconfig
+      - test $PREFIX/pkgconfig/{{ each_lib }}.pc              # [unix]
+      - if not exist %LIBRARY_PREFIX%\cmake\WebPConfig.cmake exit 1  # [win]
     {% endfor %}
 
     # headers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,11 @@ source:
   url: http://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-{{ version }}.tar.gz
   sha256: f5d7ab2390b06b8a934a4fc35784291b3885b557780d099bd32f09241f9d83f9
   patches:
-    - patches/0001-match-naming-convention-used-by-nmake-also-for-windo.patch
+    - patches/0001-match-naming-convention-used-by-nmake-also-for-windo.patch  # [win]
+    - patches/0002-use-standard-location-for-cmake-config-files.patch          # [win]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_subpackage('libwebp-base') }}

--- a/recipe/patches/0001-match-naming-convention-used-by-nmake-also-for-windo.patch
+++ b/recipe/patches/0001-match-naming-convention-used-by-nmake-also-for-windo.patch
@@ -1,8 +1,8 @@
 From 11cd27f19fc93cb45e39d1c45419b9fb2878bdeb Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 21 Jul 2022 23:57:06 +0200
-Subject: [PATCH] match naming convention used by nmake also for windows build
- from CMake
+Subject: [PATCH 1/2] match naming convention used by nmake also for windows
+ build from CMake
 
 ---
  CMakeLists.txt | 7 +++++++

--- a/recipe/patches/0002-use-standard-location-for-cmake-config-files.patch
+++ b/recipe/patches/0002-use-standard-location-for-cmake-config-files.patch
@@ -1,0 +1,26 @@
+From 05161d37aba9134c0f18709cb4672020465ccecf Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Fri, 22 Jul 2022 20:24:44 +0200
+Subject: [PATCH 2/2] use standard location for cmake config files
+
+Change-Id: I22dae95363e3d61da1ae9608de4a8fc8e4902ffa
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5d8e6076..15ac65f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -731,7 +731,7 @@ install(TARGETS ${INSTALLED_LIBRARIES}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+-set(ConfigPackageLocation ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake/)
++set(ConfigPackageLocation ${CMAKE_INSTALL_PREFIX}/cmake/)
+ install(EXPORT ${PROJECT_NAME}Targets
+         NAMESPACE ${PROJECT_NAME}::
+         DESTINATION ${ConfigPackageLocation})
+-- 
+2.37.0.windows.1
+


### PR DESCRIPTION
Adds a patch to move where the CMake config files are installed. The absence of this patch doesn't break anything, so we are holding it until the next release.

Follow-up to #14, see this [comment](https://github.com/conda-forge/libwebp-base-feedstock/pull/14#issuecomment-1192812309) ff.